### PR TITLE
Fix: Simulation working

### DIFF
--- a/Processador Ciclo Unico/Processador.v
+++ b/Processador Ciclo Unico/Processador.v
@@ -1,13 +1,19 @@
 // Processador Principal (Single Cycle MIPS)
 module SingleCycleMIPS(
     input clk,                   // Sinal de clock
-    input rst                    // Sinal de reset
+    input rst,                   // Sinal de reset
+    output [31:0] pc,            // Program Counter
+    output [31:0] instruction,   // Instrução atual
+    output RegWrite,             // Sinal de escrita no registrador
+    output ALUSrc,               // Sinal de seleção da fonte do segundo operando da ALU
+    output Branch,               // Sinal de desvio condicional
+    output Jump                  // Sinal de salto incondicional
 );
     // Fios (conexões internas)
-    wire [31:0] pc, next_pc, instruction, readData1, readData2, alu_result, mem_data, sign_ext_imm;
+    wire [31:0] next_pc, readData1, readData2, alu_result, mem_data, sign_ext_imm;
     wire [4:0] writeReg;
     wire [3:0] alu_control;
-    wire zero, RegDst, ALUSrc, MemtoReg, RegWrite, MemRead, MemWrite, Branch, Jump;
+    wire zero, MemtoReg, MemRead, MemWrite;
     wire [1:0] ALUOp;
 
     // Instâncias dos módulos

--- a/Processador Ciclo Unico/Processador.vcd
+++ b/Processador Ciclo Unico/Processador.vcd
@@ -1,567 +1,340 @@
-#! /c/Source/iverilog-install/bin/vvp
-:ivl_version "12.0 (devel)" "(s20150603-1539-g2693dd32b)";
-:ivl_delay_selection "TYPICAL";
-:vpi_time_precision + 0;
-:vpi_module "C:\iverilog\lib\ivl\system.vpi";
-:vpi_module "C:\iverilog\lib\ivl\vhdl_sys.vpi";
-:vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
-:vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
-:vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
-S_00000262ac667890 .scope module, "ALU" "ALU" 2 2;
- .timescale 0 0;
-    .port_info 0 /INPUT 32 "input1";
-    .port_info 1 /INPUT 32 "input2";
-    .port_info 2 /INPUT 4 "ALUControl";
-    .port_info 3 /OUTPUT 32 "result";
-    .port_info 4 /OUTPUT 1 "zero";
-o00000262ac68b4b8 .functor BUFZ 4, C4<zzzz>; HiZ drive
-v00000262ac687e80_0 .net "ALUControl", 3 0, o00000262ac68b4b8;  0 drivers
-o00000262ac68b4e8 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac687c00_0 .net "input1", 31 0, o00000262ac68b4e8;  0 drivers
-o00000262ac68b518 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac687d40_0 .net "input2", 31 0, o00000262ac68b518;  0 drivers
-v00000262ac687ca0_0 .var "result", 31 0;
-v00000262ac687840_0 .var "zero", 0 0;
-E_00000262ac659d60 .event anyedge, v00000262ac687e80_0, v00000262ac687c00_0, v00000262ac687d40_0, v00000262ac687ca0_0;
-S_00000262ac667a20 .scope module, "ALUControl" "ALUControl" 2 51;
- .timescale 0 0;
-    .port_info 0 /INPUT 2 "ALUOp";
-    .port_info 1 /INPUT 6 "funct";
-    .port_info 2 /OUTPUT 4 "alu_control";
-o00000262ac68b698 .functor BUFZ 2, C4<zz>; HiZ drive
-v00000262ac6881a0_0 .net "ALUOp", 1 0, o00000262ac68b698;  0 drivers
-v00000262ac687de0_0 .var "alu_control", 3 0;
-o00000262ac68b6f8 .functor BUFZ 6, C4<zzzzzz>; HiZ drive
-v00000262ac687520_0 .net "funct", 5 0, o00000262ac68b6f8;  0 drivers
-E_00000262ac65a4a0 .event anyedge, v00000262ac6881a0_0, v00000262ac687520_0;
-S_00000262ac66e330 .scope module, "ControlUnit" "ControlUnit" 3 2;
- .timescale 0 0;
-    .port_info 0 /INPUT 6 "opcode";
-    .port_info 1 /OUTPUT 1 "RegDst";
-    .port_info 2 /OUTPUT 1 "ALUSrc";
-    .port_info 3 /OUTPUT 1 "MemtoReg";
-    .port_info 4 /OUTPUT 1 "RegWrite";
-    .port_info 5 /OUTPUT 1 "MemRead";
-    .port_info 6 /OUTPUT 1 "MemWrite";
-    .port_info 7 /OUTPUT 1 "Branch";
-    .port_info 8 /OUTPUT 1 "Jump";
-    .port_info 9 /OUTPUT 2 "ALUOp";
-v00000262ac6878e0_0 .var "ALUOp", 1 0;
-v00000262ac6875c0_0 .var "ALUSrc", 0 0;
-v00000262ac687b60_0 .var "Branch", 0 0;
-v00000262ac687a20_0 .var "Jump", 0 0;
-v00000262ac687f20_0 .var "MemRead", 0 0;
-v00000262ac687660_0 .var "MemWrite", 0 0;
-v00000262ac688060_0 .var "MemtoReg", 0 0;
-v00000262ac688100_0 .var "RegDst", 0 0;
-v00000262ac6872a0_0 .var "RegWrite", 0 0;
-o00000262ac68b968 .functor BUFZ 6, C4<zzzzzz>; HiZ drive
-v00000262ac687340_0 .net "opcode", 5 0, o00000262ac68b968;  0 drivers
-E_00000262ac65a3a0 .event anyedge, v00000262ac687340_0;
-S_00000262ac66e570 .scope module, "DataMemory" "DataMemory" 4 2;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "MemRead";
-    .port_info 2 /INPUT 1 "MemWrite";
-    .port_info 3 /INPUT 32 "address";
-    .port_info 4 /INPUT 32 "writeData";
-    .port_info 5 /OUTPUT 32 "readData";
-o00000262ac68bb78 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac687700_0 .net "MemRead", 0 0, o00000262ac68bb78;  0 drivers
-o00000262ac68bba8 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac687ac0_0 .net "MemWrite", 0 0, o00000262ac68bba8;  0 drivers
-v00000262ac6873e0_0 .net *"_ivl_0", 31 0, L_00000262ac6e2120;  1 drivers
-v00000262ac687480_0 .net *"_ivl_3", 7 0, L_00000262ac6e2bc0;  1 drivers
-v00000262ac6e2b20_0 .net *"_ivl_4", 9 0, L_00000262ac6e3660;  1 drivers
-L_00000262ac7d0088 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v00000262ac6e2440_0 .net *"_ivl_7", 1 0, L_00000262ac7d0088;  1 drivers
-L_00000262ac7d00d0 .functor BUFT 1, C4<00000000000000000000000000000000>, C4<0>, C4<0>, C4<0>;
-v00000262ac6e3c00_0 .net/2u *"_ivl_8", 31 0, L_00000262ac7d00d0;  1 drivers
-o00000262ac68bcc8 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e2080_0 .net "address", 31 0, o00000262ac68bcc8;  0 drivers
-o00000262ac68bcf8 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac6e3980_0 .net "clk", 0 0, o00000262ac68bcf8;  0 drivers
-v00000262ac6e3e80 .array "memory", 255 0, 31 0;
-v00000262ac6e3ac0_0 .net "readData", 31 0, L_00000262ac6e2260;  1 drivers
-o00000262ac68bd58 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e26c0_0 .net "writeData", 31 0, o00000262ac68bd58;  0 drivers
-E_00000262ac65a120 .event posedge, v00000262ac6e3980_0;
-L_00000262ac6e2120 .array/port v00000262ac6e3e80, L_00000262ac6e3660;
-L_00000262ac6e2bc0 .part o00000262ac68bcc8, 0, 8;
-L_00000262ac6e3660 .concat [ 8 2 0 0], L_00000262ac6e2bc0, L_00000262ac7d0088;
-L_00000262ac6e2260 .functor MUXZ 32, L_00000262ac7d00d0, L_00000262ac6e2120, o00000262ac68bb78, C4<>;
-S_00000262ac7cc200 .scope module, "InstructionMemory" "InstructionMemory" 4 37;
- .timescale 0 0;
-    .port_info 0 /INPUT 32 "address";
-    .port_info 1 /OUTPUT 32 "instruction";
-L_00000262ac676e10 .functor BUFZ 32, L_00000262ac6e3700, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
-v00000262ac6e2580_0 .net *"_ivl_0", 31 0, L_00000262ac6e3700;  1 drivers
-v00000262ac6e3200_0 .net *"_ivl_3", 7 0, L_00000262ac6e2da0;  1 drivers
-v00000262ac6e3160_0 .net *"_ivl_4", 9 0, L_00000262ac6e2c60;  1 drivers
-L_00000262ac7d0118 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v00000262ac6e2620_0 .net *"_ivl_7", 1 0, L_00000262ac7d0118;  1 drivers
-o00000262ac68bf68 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e21c0_0 .net "address", 31 0, o00000262ac68bf68;  0 drivers
-v00000262ac6e2e40_0 .net "instruction", 31 0, L_00000262ac676e10;  1 drivers
-v00000262ac6e35c0 .array "memory", 255 0, 31 0;
-L_00000262ac6e3700 .array/port v00000262ac6e35c0, L_00000262ac6e2c60;
-L_00000262ac6e2da0 .part o00000262ac68bf68, 0, 8;
-L_00000262ac6e2c60 .concat [ 8 2 0 0], L_00000262ac6e2da0, L_00000262ac7d0118;
-S_00000262ac7cc390 .scope module, "PC" "PC" 4 22;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "rst";
-    .port_info 2 /INPUT 32 "next_pc";
-    .port_info 3 /OUTPUT 32 "pc";
-o00000262ac68c028 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac6e3a20_0 .net "clk", 0 0, o00000262ac68c028;  0 drivers
-o00000262ac68c058 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e2ee0_0 .net "next_pc", 31 0, o00000262ac68c058;  0 drivers
-v00000262ac6e24e0_0 .var "pc", 31 0;
-o00000262ac68c0b8 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac6e3ca0_0 .net "rst", 0 0, o00000262ac68c0b8;  0 drivers
-E_00000262ac65a560 .event posedge, v00000262ac6e3ca0_0, v00000262ac6e3a20_0;
-S_00000262ac7ce2a0 .scope module, "Registers" "Registers" 2 22;
- .timescale 0 0;
-    .port_info 0 /INPUT 1 "clk";
-    .port_info 1 /INPUT 1 "RegWrite";
-    .port_info 2 /INPUT 5 "readReg1";
-    .port_info 3 /INPUT 5 "readReg2";
-    .port_info 4 /INPUT 5 "writeReg";
-    .port_info 5 /INPUT 32 "writeData";
-    .port_info 6 /OUTPUT 32 "readData1";
-    .port_info 7 /OUTPUT 32 "readData2";
-L_00000262ac677040 .functor BUFZ 32, L_00000262ac6e2300, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
-L_00000262ac677ba0 .functor BUFZ 32, L_00000262ac6e3840, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
-o00000262ac68c1a8 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac6e2800_0 .net "RegWrite", 0 0, o00000262ac68c1a8;  0 drivers
-v00000262ac6e28a0_0 .net *"_ivl_0", 31 0, L_00000262ac6e2300;  1 drivers
-v00000262ac6e2760_0 .net *"_ivl_10", 6 0, L_00000262ac6e38e0;  1 drivers
-L_00000262ac7d01a8 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v00000262ac6e3480_0 .net *"_ivl_13", 1 0, L_00000262ac7d01a8;  1 drivers
-v00000262ac6e3b60_0 .net *"_ivl_2", 6 0, L_00000262ac6e23a0;  1 drivers
-L_00000262ac7d0160 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
-v00000262ac6e32a0_0 .net *"_ivl_5", 1 0, L_00000262ac7d0160;  1 drivers
-v00000262ac6e3d40_0 .net *"_ivl_8", 31 0, L_00000262ac6e3840;  1 drivers
-o00000262ac68c2f8 .functor BUFZ 1, C4<z>; HiZ drive
-v00000262ac6e3520_0 .net "clk", 0 0, o00000262ac68c2f8;  0 drivers
-v00000262ac6e2940_0 .var/i "i", 31 0;
-v00000262ac6e2f80_0 .net "readData1", 31 0, L_00000262ac677040;  1 drivers
-v00000262ac6e3020_0 .net "readData2", 31 0, L_00000262ac677ba0;  1 drivers
-o00000262ac68c3b8 .functor BUFZ 5, C4<zzzzz>; HiZ drive
-v00000262ac6e29e0_0 .net "readReg1", 4 0, o00000262ac68c3b8;  0 drivers
-o00000262ac68c3e8 .functor BUFZ 5, C4<zzzzz>; HiZ drive
-v00000262ac6e3340_0 .net "readReg2", 4 0, o00000262ac68c3e8;  0 drivers
-v00000262ac6e37a0 .array "regFile", 0 31, 31 0;
-o00000262ac68c418 .functor BUFZ 32, C4<zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e2a80_0 .net "writeData", 31 0, o00000262ac68c418;  0 drivers
-o00000262ac68c448 .functor BUFZ 5, C4<zzzzz>; HiZ drive
-v00000262ac6e2d00_0 .net "writeReg", 4 0, o00000262ac68c448;  0 drivers
-E_00000262ac659e20 .event posedge, v00000262ac6e3520_0;
-L_00000262ac6e2300 .array/port v00000262ac6e37a0, L_00000262ac6e23a0;
-L_00000262ac6e23a0 .concat [ 5 2 0 0], o00000262ac68c3b8, L_00000262ac7d0160;
-L_00000262ac6e3840 .array/port v00000262ac6e37a0, L_00000262ac6e38e0;
-L_00000262ac6e38e0 .concat [ 5 2 0 0], o00000262ac68c3e8, L_00000262ac7d01a8;
-S_00000262ac7ce430 .scope module, "SignExtend" "SignExtend" 4 53;
- .timescale 0 0;
-    .port_info 0 /INPUT 16 "in";
-    .port_info 1 /OUTPUT 32 "out";
-v00000262ac6e33e0_0 .net *"_ivl_1", 0 0, L_00000262ac6f5360;  1 drivers
-v00000262ac6e3de0_0 .net *"_ivl_2", 15 0, L_00000262ac6f5860;  1 drivers
-o00000262ac68c658 .functor BUFZ 16, C4<zzzzzzzzzzzzzzzz>; HiZ drive
-v00000262ac6e3f20_0 .net "in", 15 0, o00000262ac68c658;  0 drivers
-v00000262ac6e30c0_0 .net "out", 31 0, L_00000262ac6f4f00;  1 drivers
-L_00000262ac6f5360 .part o00000262ac68c658, 15, 1;
-LS_00000262ac6f5860_0_0 .concat [ 1 1 1 1], L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360;
-LS_00000262ac6f5860_0_4 .concat [ 1 1 1 1], L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360;
-LS_00000262ac6f5860_0_8 .concat [ 1 1 1 1], L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360;
-LS_00000262ac6f5860_0_12 .concat [ 1 1 1 1], L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360, L_00000262ac6f5360;
-L_00000262ac6f5860 .concat [ 4 4 4 4], LS_00000262ac6f5860_0_0, LS_00000262ac6f5860_0_4, LS_00000262ac6f5860_0_8, LS_00000262ac6f5860_0_12;
-L_00000262ac6f4f00 .concat [ 16 16 0 0], o00000262ac68c658, L_00000262ac6f5860;
-    .scope S_00000262ac667890;
-T_0 ;
-    %wait E_00000262ac659d60;
-    %load/vec4 v00000262ac687e80_0;
-    %dup/vec4;
-    %pushi/vec4 2, 0, 4;
-    %cmp/u;
-    %jmp/1 T_0.0, 6;
-    %dup/vec4;
-    %pushi/vec4 6, 0, 4;
-    %cmp/u;
-    %jmp/1 T_0.1, 6;
-    %dup/vec4;
-    %pushi/vec4 0, 0, 4;
-    %cmp/u;
-    %jmp/1 T_0.2, 6;
-    %dup/vec4;
-    %pushi/vec4 1, 0, 4;
-    %cmp/u;
-    %jmp/1 T_0.3, 6;
-    %dup/vec4;
-    %pushi/vec4 7, 0, 4;
-    %cmp/u;
-    %jmp/1 T_0.4, 6;
-    %pushi/vec4 0, 0, 32;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.0 ;
-    %load/vec4 v00000262ac687c00_0;
-    %load/vec4 v00000262ac687d40_0;
-    %add;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.1 ;
-    %load/vec4 v00000262ac687c00_0;
-    %load/vec4 v00000262ac687d40_0;
-    %sub;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.2 ;
-    %load/vec4 v00000262ac687c00_0;
-    %load/vec4 v00000262ac687d40_0;
-    %and;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.3 ;
-    %load/vec4 v00000262ac687c00_0;
-    %load/vec4 v00000262ac687d40_0;
-    %or;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.4 ;
-    %load/vec4 v00000262ac687c00_0;
-    %load/vec4 v00000262ac687d40_0;
-    %cmp/u;
-    %flag_mov 8, 5;
-    %jmp/0 T_0.7, 8;
-    %pushi/vec4 1, 0, 32;
-    %jmp/1 T_0.8, 8;
-T_0.7 ; End of true expr.
-    %pushi/vec4 0, 0, 32;
-    %jmp/0 T_0.8, 8;
- ; End of false expr.
-    %blend;
-T_0.8;
-    %store/vec4 v00000262ac687ca0_0, 0, 32;
-    %jmp T_0.6;
-T_0.6 ;
-    %pop/vec4 1;
-    %load/vec4 v00000262ac687ca0_0;
-    %cmpi/e 0, 0, 32;
-    %flag_mov 8, 4;
-    %jmp/0 T_0.9, 8;
-    %pushi/vec4 1, 0, 2;
-    %jmp/1 T_0.10, 8;
-T_0.9 ; End of true expr.
-    %pushi/vec4 0, 0, 2;
-    %jmp/0 T_0.10, 8;
- ; End of false expr.
-    %blend;
-T_0.10;
-    %pad/s 1;
-    %store/vec4 v00000262ac687840_0, 0, 1;
-    %jmp T_0;
-    .thread T_0, $push;
-    .scope S_00000262ac667a20;
-T_1 ;
-    %wait E_00000262ac65a4a0;
-    %load/vec4 v00000262ac6881a0_0;
-    %dup/vec4;
-    %pushi/vec4 0, 0, 2;
-    %cmp/u;
-    %jmp/1 T_1.0, 6;
-    %dup/vec4;
-    %pushi/vec4 1, 0, 2;
-    %cmp/u;
-    %jmp/1 T_1.1, 6;
-    %dup/vec4;
-    %pushi/vec4 2, 0, 2;
-    %cmp/u;
-    %jmp/1 T_1.2, 6;
-    %pushi/vec4 0, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.4;
-T_1.0 ;
-    %pushi/vec4 2, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.4;
-T_1.1 ;
-    %pushi/vec4 6, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.4;
-T_1.2 ;
-    %load/vec4 v00000262ac687520_0;
-    %dup/vec4;
-    %pushi/vec4 32, 0, 6;
-    %cmp/u;
-    %jmp/1 T_1.5, 6;
-    %dup/vec4;
-    %pushi/vec4 34, 0, 6;
-    %cmp/u;
-    %jmp/1 T_1.6, 6;
-    %dup/vec4;
-    %pushi/vec4 36, 0, 6;
-    %cmp/u;
-    %jmp/1 T_1.7, 6;
-    %dup/vec4;
-    %pushi/vec4 37, 0, 6;
-    %cmp/u;
-    %jmp/1 T_1.8, 6;
-    %dup/vec4;
-    %pushi/vec4 42, 0, 6;
-    %cmp/u;
-    %jmp/1 T_1.9, 6;
-    %pushi/vec4 0, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.5 ;
-    %pushi/vec4 2, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.6 ;
-    %pushi/vec4 6, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.7 ;
-    %pushi/vec4 0, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.8 ;
-    %pushi/vec4 1, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.9 ;
-    %pushi/vec4 7, 0, 4;
-    %store/vec4 v00000262ac687de0_0, 0, 4;
-    %jmp T_1.11;
-T_1.11 ;
-    %pop/vec4 1;
-    %jmp T_1.4;
-T_1.4 ;
-    %pop/vec4 1;
-    %jmp T_1;
-    .thread T_1, $push;
-    .scope S_00000262ac66e330;
-T_2 ;
-    %wait E_00000262ac65a3a0;
-    %load/vec4 v00000262ac687340_0;
-    %dup/vec4;
-    %pushi/vec4 0, 0, 6;
-    %cmp/u;
-    %jmp/1 T_2.0, 6;
-    %dup/vec4;
-    %pushi/vec4 35, 0, 6;
-    %cmp/u;
-    %jmp/1 T_2.1, 6;
-    %dup/vec4;
-    %pushi/vec4 43, 0, 6;
-    %cmp/u;
-    %jmp/1 T_2.2, 6;
-    %dup/vec4;
-    %pushi/vec4 4, 0, 6;
-    %cmp/u;
-    %jmp/1 T_2.3, 6;
-    %dup/vec4;
-    %pushi/vec4 2, 0, 6;
-    %cmp/u;
-    %jmp/1 T_2.4, 6;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 0, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.0 ;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 2, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.1 ;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 0, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.2 ;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 0, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.3 ;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 1, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.4 ;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688100_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6875c0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac688060_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac6872a0_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687f20_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687660_0, 0, 1;
-    %pushi/vec4 0, 0, 1;
-    %store/vec4 v00000262ac687b60_0, 0, 1;
-    %pushi/vec4 1, 0, 1;
-    %store/vec4 v00000262ac687a20_0, 0, 1;
-    %pushi/vec4 0, 0, 2;
-    %store/vec4 v00000262ac6878e0_0, 0, 2;
-    %jmp T_2.6;
-T_2.6 ;
-    %pop/vec4 1;
-    %jmp T_2;
-    .thread T_2, $push;
-    .scope S_00000262ac66e570;
-T_3 ;
-    %wait E_00000262ac65a120;
-    %load/vec4 v00000262ac687ac0_0;
-    %flag_set/vec4 8;
-    %jmp/0xz  T_3.0, 8;
-    %load/vec4 v00000262ac6e26c0_0;
-    %load/vec4 v00000262ac6e2080_0;
-    %parti/s 8, 0, 2;
-    %pad/u 10;
-    %ix/vec4 3;
-    %ix/load 4, 0, 0; Constant delay
-    %assign/vec4/a/d v00000262ac6e3e80, 0, 4;
-T_3.0 ;
-    %jmp T_3;
-    .thread T_3;
-    .scope S_00000262ac7cc200;
-T_4 ;
-    %vpi_call 4 45 "$readmemh", "Test.mem", v00000262ac6e35c0 {0 0 0};
-    %end;
-    .thread T_4;
-    .scope S_00000262ac7cc390;
-T_5 ;
-    %wait E_00000262ac65a560;
-    %load/vec4 v00000262ac6e3ca0_0;
-    %flag_set/vec4 8;
-    %jmp/0xz  T_5.0, 8;
-    %pushi/vec4 0, 0, 32;
-    %assign/vec4 v00000262ac6e24e0_0, 0;
-    %jmp T_5.1;
-T_5.0 ;
-    %load/vec4 v00000262ac6e2ee0_0;
-    %assign/vec4 v00000262ac6e24e0_0, 0;
-T_5.1 ;
-    %jmp T_5;
-    .thread T_5;
-    .scope S_00000262ac7ce2a0;
-T_6 ;
-    %pushi/vec4 0, 0, 32;
-    %store/vec4 v00000262ac6e2940_0, 0, 32;
-T_6.0 ;
-    %load/vec4 v00000262ac6e2940_0;
-    %cmpi/s 32, 0, 32;
-    %jmp/0xz T_6.1, 5;
-    %pushi/vec4 0, 0, 32;
-    %ix/getv/s 4, v00000262ac6e2940_0;
-    %store/vec4a v00000262ac6e37a0, 4, 0;
-    %load/vec4 v00000262ac6e2940_0;
-    %addi 1, 0, 32;
-    %store/vec4 v00000262ac6e2940_0, 0, 32;
-    %jmp T_6.0;
-T_6.1 ;
-    %end;
-    .thread T_6;
-    .scope S_00000262ac7ce2a0;
-T_7 ;
-    %wait E_00000262ac659e20;
-    %load/vec4 v00000262ac6e2800_0;
-    %flag_set/vec4 8;
-    %jmp/0xz  T_7.0, 8;
-    %load/vec4 v00000262ac6e2a80_0;
-    %load/vec4 v00000262ac6e2d00_0;
-    %pad/u 7;
-    %ix/vec4 3;
-    %ix/load 4, 0, 0; Constant delay
-    %assign/vec4/a/d v00000262ac6e37a0, 0, 4;
-T_7.0 ;
-    %jmp T_7;
-    .thread T_7;
-# The file index is used to find the file name in the following table.
-:file_names 5;
-    "N/A";
-    "<interactive>";
-    "AluAndRegistradores.v";
-    "UnidadeDeControle.v";
-    "memory.v";
+$date
+	Mon Feb  3 10:47:58 2025
+$end
+$version
+	Icarus Verilog
+$end
+$timescale
+	1ps
+$end
+$scope module SingleCycleMIPS_Simulation $end
+$scope module uut $end
+$var wire 1 ! clk $end
+$var wire 1 " rst $end
+$var wire 1 # zero $end
+$var wire 5 $ writeReg [4:0] $end
+$var wire 32 % sign_ext_imm [31:0] $end
+$var wire 32 & readData2 [31:0] $end
+$var wire 32 ' readData1 [31:0] $end
+$var wire 32 ( pc [31:0] $end
+$var wire 32 ) next_pc [31:0] $end
+$var wire 32 * mem_data [31:0] $end
+$var wire 32 + jump_address [31:0] $end
+$var wire 32 , instruction [31:0] $end
+$var wire 32 - alu_result [31:0] $end
+$var wire 4 . alu_control [3:0] $end
+$var wire 1 / RegWrite $end
+$var wire 1 0 RegDst $end
+$var wire 1 1 MemtoReg $end
+$var wire 1 2 MemWrite $end
+$var wire 1 3 MemRead $end
+$var wire 1 4 Jump $end
+$var wire 1 5 Branch $end
+$var wire 1 6 ALUSrc $end
+$var wire 2 7 ALUOp [1:0] $end
+$scope module alu $end
+$var wire 32 8 input2 [31:0] $end
+$var wire 32 9 input1 [31:0] $end
+$var wire 4 : ALUControl [3:0] $end
+$var reg 32 ; result [31:0] $end
+$var reg 1 # zero $end
+$upscope $end
+$scope module alu_ctrl $end
+$var wire 6 < funct [5:0] $end
+$var wire 2 = ALUOp [1:0] $end
+$var reg 4 > alu_control [3:0] $end
+$upscope $end
+$scope module control $end
+$var wire 6 ? opcode [5:0] $end
+$var reg 2 @ ALUOp [1:0] $end
+$var reg 1 6 ALUSrc $end
+$var reg 1 5 Branch $end
+$var reg 1 4 Jump $end
+$var reg 1 3 MemRead $end
+$var reg 1 2 MemWrite $end
+$var reg 1 1 MemtoReg $end
+$var reg 1 0 RegDst $end
+$var reg 1 / RegWrite $end
+$upscope $end
+$scope module data_mem $end
+$var wire 1 3 MemRead $end
+$var wire 1 2 MemWrite $end
+$var wire 32 A address [31:0] $end
+$var wire 1 ! clk $end
+$var wire 32 B writeData [31:0] $end
+$var wire 32 C readData [31:0] $end
+$upscope $end
+$scope module inst_mem $end
+$var wire 32 D instruction [31:0] $end
+$var wire 32 E address [31:0] $end
+$upscope $end
+$scope module pc_reg $end
+$var wire 1 ! clk $end
+$var wire 32 F next_pc [31:0] $end
+$var wire 1 " rst $end
+$var reg 32 G pc [31:0] $end
+$upscope $end
+$scope module reg_file $end
+$var wire 1 / RegWrite $end
+$var wire 1 ! clk $end
+$var wire 32 H readData1 [31:0] $end
+$var wire 32 I readData2 [31:0] $end
+$var wire 5 J readReg1 [4:0] $end
+$var wire 5 K readReg2 [4:0] $end
+$var wire 32 L writeData [31:0] $end
+$var wire 5 M writeReg [4:0] $end
+$var integer 32 N i [31:0] $end
+$upscope $end
+$scope module sign_ext $end
+$var wire 16 O in [15:0] $end
+$var wire 32 P out [31:0] $end
+$upscope $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+$end
+#0
+$dumpvars
+b1010 P
+b1010 O
+b100000 N
+b0 M
+b0 L
+b0 K
+b0 J
+b0 I
+b0 H
+b0 G
+b100 F
+b0 E
+b1010 D
+b0 C
+b0 B
+b0 A
+b10 @
+b0 ?
+b0 >
+b10 =
+b1010 <
+b0 ;
+b0 :
+b0 9
+b0 8
+b10 7
+06
+05
+04
+03
+02
+01
+10
+1/
+b0 .
+b0 -
+b1010 ,
+b101000 +
+b0 *
+b100 )
+b0 (
+b0 '
+b0 &
+b1010 %
+b0 $
+1#
+1"
+0!
+$end
+#5000
+1!
+#10000
+0!
+0"
+#15000
+b0 +
+b0 <
+b0 %
+b0 P
+b0 O
+b1000 )
+b1000 F
+b0 ,
+b0 D
+b100 (
+b100 E
+b100 G
+1!
+#20000
+0!
+#25000
+b1100 )
+b1100 F
+b1000 (
+b1000 E
+b1000 G
+1!
+#30000
+0!
+#35000
+b10000 )
+b10000 F
+b1100 (
+b1100 E
+b1100 G
+1!
+#40000
+0!
+#45000
+b10100 )
+b10100 F
+b10000 (
+b10000 E
+b10000 G
+1!
+#50000
+0!
+#55000
+b11000 )
+b11000 F
+b10100 (
+b10100 E
+b10100 G
+1!
+#60000
+0!
+#65000
+b11100 )
+b11100 F
+b11000 (
+b11000 E
+b11000 G
+1!
+#70000
+0!
+#75000
+b100000 )
+b100000 F
+b11100 (
+b11100 E
+b11100 G
+1!
+#80000
+0!
+#85000
+b100100 )
+b100100 F
+b100000 (
+b100000 E
+b100000 G
+1!
+#90000
+0!
+#95000
+b101000 )
+b101000 F
+b100100 (
+b100100 E
+b100100 G
+1!
+#100000
+0!
+#105000
+b101100 )
+b101100 F
+b101000 (
+b101000 E
+b101000 G
+1!
+#110000
+0!
+#115000
+b110000 )
+b110000 F
+b101100 (
+b101100 E
+b101100 G
+1!
+#120000
+0!
+#125000
+b110100 )
+b110100 F
+b110000 (
+b110000 E
+b110000 G
+1!
+#130000
+0!
+#135000
+b111000 )
+b111000 F
+b110100 (
+b110100 E
+b110100 G
+1!
+#140000
+0!
+#145000
+b111100 )
+b111100 F
+b111000 (
+b111000 E
+b111000 G
+1!
+#150000
+0!
+#155000
+b1000000 )
+b1000000 F
+b111100 (
+b111100 E
+b111100 G
+1!
+#160000
+0!
+#165000
+b1000100 )
+b1000100 F
+b1000000 (
+b1000000 E
+b1000000 G
+1!
+#170000
+0!
+#175000
+b1001000 )
+b1001000 F
+b1000100 (
+b1000100 E
+b1000100 G
+1!
+#180000
+0!
+#185000
+b1001100 )
+b1001100 F
+b1001000 (
+b1001000 E
+b1001000 G
+1!
+#190000
+0!
+#195000
+b1010000 )
+b1010000 F
+b1001100 (
+b1001100 E
+b1001100 G
+1!
+#200000
+0!
+#205000
+b1010100 )
+b1010100 F
+b1010000 (
+b1010000 E
+b1010000 G
+1!
+#210000
+0!

--- a/Processador Ciclo Unico/issue.md
+++ b/Processador Ciclo Unico/issue.md
@@ -1,0 +1,47 @@
+# Descrição das Modificações
+
+## Arquivo: simulacao.v
+
+### Modificações:
+1. Adição de fios (`wire`) para `RegWrite`, `ALUSrc`, `Branch` e `Jump`.
+2. Conexão dos fios aos sinais correspondentes na instância do processador (`uut`).
+3. Correção das referências aos registradores e memória dentro da instância do processador (`uut`).
+
+### Razões:
+- As modificações foram necessárias para corrigir os erros de ligação de sinais e referências internas na simulação. Os sinais `RegWrite`, `ALUSrc`, `Branch` e `Jump` precisavam ser conectados corretamente à instância do processador para monitoramento durante a simulação.
+
+## Arquivo: Processador.v
+
+### Modificações:
+1. Adição de portas de saída (`output`) para `pc`, `instruction`, `RegWrite`, `ALUSrc`, `Branch` e `Jump`.
+
+### Razões:
+- As portas de saída foram adicionadas para expor os sinais internos do processador, permitindo que eles sejam monitorados na simulação (`simulacao.v`). Isso é essencial para verificar o comportamento do processador durante a execução das instruções.
+
+## Arquivo: UnidadeDeControle.v
+
+### Modificações:
+Nenhuma modificação necessária.
+
+### Razões:
+- O arquivo `UnidadeDeControle.v` já estava correto e não necessitou de alterações.
+
+## Arquivo: memory.v
+
+### Modificações:
+Nenhuma modificação necessária.
+
+### Razões:
+- O arquivo `memory.v` já estava correto e não necessitou de alterações.
+
+## Arquivo: AluAndRegistradores.v
+
+### Modificações:
+Nenhuma modificação necessária.
+
+### Razões:
+- O arquivo `AluAndRegistradores.v` já estava correto e não necessitou de alterações.
+
+# Conclusão
+
+As modificações realizadas foram essenciais para corrigir os erros de ligação de sinais e referências internas na simulação do processador de ciclo único. Com essas mudanças, a simulação agora pode monitorar corretamente os sinais internos do processador, permitindo uma verificação mais precisa do seu comportamento.

--- a/Processador Ciclo Unico/output.vvp
+++ b/Processador Ciclo Unico/output.vvp
@@ -1,0 +1,786 @@
+#! /usr/bin/vvp
+:ivl_version "12.0 (stable)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision - 12;
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/system.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_sys.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_textio.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/v2005_math.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/va_math.vpi";
+S_0x55ef6e7aaf20 .scope module, "SingleCycleMIPS_Simulation" "SingleCycleMIPS_Simulation" 2 3;
+ .timescale -9 -12;
+v0x55ef6e7d7510_0 .net "ALUSrc", 0 0, v0x55ef6e7d1700_0;  1 drivers
+v0x55ef6e7d75d0_0 .net "Branch", 0 0, v0x55ef6e7d17a0_0;  1 drivers
+v0x55ef6e7d76e0_0 .net "Jump", 0 0, v0x55ef6e7d1840_0;  1 drivers
+v0x55ef6e7d77d0_0 .net "RegWrite", 0 0, v0x55ef6e7d1c50_0;  1 drivers
+v0x55ef6e7d7870_0 .var "clk", 0 0;
+v0x55ef6e7d7960_0 .net "instruction", 31 0, L_0x55ef6e7b2bc0;  1 drivers
+v0x55ef6e7d7a00_0 .net "pc", 31 0, v0x55ef6e7d3980_0;  1 drivers
+v0x55ef6e7d7aa0_0 .var "rst", 0 0;
+S_0x55ef6e7a7250 .scope module, "uut" "SingleCycleMIPS" 2 15, 3 2 0, S_0x55ef6e7aaf20;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /OUTPUT 32 "pc";
+    .port_info 3 /OUTPUT 32 "instruction";
+    .port_info 4 /OUTPUT 1 "RegWrite";
+    .port_info 5 /OUTPUT 1 "ALUSrc";
+    .port_info 6 /OUTPUT 1 "Branch";
+    .port_info 7 /OUTPUT 1 "Jump";
+L_0x55ef6e7e9ac0 .functor AND 1, v0x55ef6e7d17a0_0, v0x55ef6e7d0c20_0, C4<1>, C4<1>;
+v0x55ef6e7d53e0_0 .net "ALUOp", 1 0, v0x55ef6e7d1640_0;  1 drivers
+v0x55ef6e7d54f0_0 .net "ALUSrc", 0 0, v0x55ef6e7d1700_0;  alias, 1 drivers
+v0x55ef6e7d55b0_0 .net "Branch", 0 0, v0x55ef6e7d17a0_0;  alias, 1 drivers
+v0x55ef6e7d56b0_0 .net "Jump", 0 0, v0x55ef6e7d1840_0;  alias, 1 drivers
+v0x55ef6e7d5780_0 .net "MemRead", 0 0, v0x55ef6e7d1900_0;  1 drivers
+v0x55ef6e7d58c0_0 .net "MemWrite", 0 0, v0x55ef6e7d1a10_0;  1 drivers
+v0x55ef6e7d59b0_0 .net "MemtoReg", 0 0, v0x55ef6e7d1ad0_0;  1 drivers
+v0x55ef6e7d5a50_0 .net "RegDst", 0 0, v0x55ef6e7d1b90_0;  1 drivers
+v0x55ef6e7d5af0_0 .net "RegWrite", 0 0, v0x55ef6e7d1c50_0;  alias, 1 drivers
+v0x55ef6e7d5c20_0 .net *"_ivl_13", 4 0, L_0x55ef6e7e9400;  1 drivers
+v0x55ef6e7d5cc0_0 .net *"_ivl_15", 4 0, L_0x55ef6e7e94a0;  1 drivers
+v0x55ef6e7d5d60_0 .net *"_ivl_19", 3 0, L_0x55ef6e7e9770;  1 drivers
+v0x55ef6e7d5e00_0 .net *"_ivl_21", 25 0, L_0x55ef6e7e9870;  1 drivers
+L_0x7ff41cabc180 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d5ec0_0 .net/2u *"_ivl_22", 1 0, L_0x7ff41cabc180;  1 drivers
+v0x55ef6e7d5fa0_0 .net *"_ivl_26", 0 0, L_0x55ef6e7e9ac0;  1 drivers
+L_0x7ff41cabc1c8 .functor BUFT 1, C4<00000000000000000000000000000100>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d6080_0 .net/2u *"_ivl_28", 31 0, L_0x7ff41cabc1c8;  1 drivers
+v0x55ef6e7d6160_0 .net *"_ivl_30", 31 0, L_0x55ef6e7e9b80;  1 drivers
+v0x55ef6e7d6240_0 .net *"_ivl_32", 31 0, L_0x55ef6e7e9e00;  1 drivers
+v0x55ef6e7d6320_0 .net *"_ivl_34", 29 0, L_0x55ef6e7e9ce0;  1 drivers
+L_0x7ff41cabc210 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d6400_0 .net *"_ivl_36", 1 0, L_0x7ff41cabc210;  1 drivers
+v0x55ef6e7d64e0_0 .net *"_ivl_38", 31 0, L_0x55ef6e7e9ef0;  1 drivers
+L_0x7ff41cabc258 .functor BUFT 1, C4<00000000000000000000000000000100>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d65c0_0 .net/2u *"_ivl_40", 31 0, L_0x7ff41cabc258;  1 drivers
+v0x55ef6e7d66a0_0 .net *"_ivl_42", 31 0, L_0x55ef6e7ea150;  1 drivers
+v0x55ef6e7d6780_0 .net *"_ivl_44", 31 0, L_0x55ef6e7ea1f0;  1 drivers
+v0x55ef6e7d6860_0 .net "alu_control", 3 0, v0x55ef6e7d1160_0;  1 drivers
+v0x55ef6e7d6970_0 .net "alu_result", 31 0, v0x55ef6e7d0b40_0;  1 drivers
+v0x55ef6e7d6a80_0 .net "clk", 0 0, v0x55ef6e7d7870_0;  1 drivers
+v0x55ef6e7d6b20_0 .net "instruction", 31 0, L_0x55ef6e7b2bc0;  alias, 1 drivers
+v0x55ef6e7d6be0_0 .net "jump_address", 31 0, L_0x55ef6e7e9910;  1 drivers
+v0x55ef6e7d6ca0_0 .net "mem_data", 31 0, L_0x55ef6e7e9290;  1 drivers
+v0x55ef6e7d6db0_0 .net "next_pc", 31 0, L_0x55ef6e7ea420;  1 drivers
+v0x55ef6e7d6e70_0 .net "pc", 31 0, v0x55ef6e7d3980_0;  alias, 1 drivers
+v0x55ef6e7d6f60_0 .net "readData1", 31 0, L_0x55ef6e7d81f0;  1 drivers
+v0x55ef6e7d7070_0 .net "readData2", 31 0, L_0x55ef6e7d84c0;  1 drivers
+v0x55ef6e7d7180_0 .net "rst", 0 0, v0x55ef6e7d7aa0_0;  1 drivers
+v0x55ef6e7d7220_0 .net "sign_ext_imm", 31 0, L_0x55ef6e7d8c20;  1 drivers
+v0x55ef6e7d72c0_0 .net "writeReg", 4 0, L_0x55ef6e7e9590;  1 drivers
+v0x55ef6e7d7360_0 .net "zero", 0 0, v0x55ef6e7d0c20_0;  1 drivers
+L_0x55ef6e7d7f10 .part L_0x55ef6e7b2bc0, 26, 6;
+L_0x55ef6e7d8580 .part L_0x55ef6e7b2bc0, 21, 5;
+L_0x55ef6e7d8670 .part L_0x55ef6e7b2bc0, 16, 5;
+L_0x55ef6e7d8d60 .part L_0x55ef6e7b2bc0, 0, 16;
+L_0x55ef6e7d8e30 .part L_0x55ef6e7b2bc0, 0, 6;
+L_0x55ef6e7d8ed0 .functor MUXZ 32, L_0x55ef6e7d84c0, L_0x55ef6e7d8c20, v0x55ef6e7d1700_0, C4<>;
+L_0x55ef6e7e9400 .part L_0x55ef6e7b2bc0, 11, 5;
+L_0x55ef6e7e94a0 .part L_0x55ef6e7b2bc0, 16, 5;
+L_0x55ef6e7e9590 .functor MUXZ 5, L_0x55ef6e7e94a0, L_0x55ef6e7e9400, v0x55ef6e7d1b90_0, C4<>;
+L_0x55ef6e7e9770 .part v0x55ef6e7d3980_0, 28, 4;
+L_0x55ef6e7e9870 .part L_0x55ef6e7b2bc0, 0, 26;
+L_0x55ef6e7e9910 .concat [ 2 26 4 0], L_0x7ff41cabc180, L_0x55ef6e7e9870, L_0x55ef6e7e9770;
+L_0x55ef6e7e9b80 .arith/sum 32, v0x55ef6e7d3980_0, L_0x7ff41cabc1c8;
+L_0x55ef6e7e9ce0 .part L_0x55ef6e7d8c20, 0, 30;
+L_0x55ef6e7e9e00 .concat [ 2 30 0 0], L_0x7ff41cabc210, L_0x55ef6e7e9ce0;
+L_0x55ef6e7e9ef0 .arith/sum 32, L_0x55ef6e7e9b80, L_0x55ef6e7e9e00;
+L_0x55ef6e7ea150 .arith/sum 32, v0x55ef6e7d3980_0, L_0x7ff41cabc258;
+L_0x55ef6e7ea1f0 .functor MUXZ 32, L_0x55ef6e7ea150, L_0x55ef6e7e9ef0, L_0x55ef6e7e9ac0, C4<>;
+L_0x55ef6e7ea420 .functor MUXZ 32, L_0x55ef6e7ea1f0, L_0x55ef6e7e9910, v0x55ef6e7d1840_0, C4<>;
+S_0x55ef6e7b5d70 .scope module, "alu" "ALU" 3 75, 4 2 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 32 "input1";
+    .port_info 1 /INPUT 32 "input2";
+    .port_info 2 /INPUT 4 "ALUControl";
+    .port_info 3 /OUTPUT 32 "result";
+    .port_info 4 /OUTPUT 1 "zero";
+v0x55ef6e7a01b0_0 .net "ALUControl", 3 0, v0x55ef6e7d1160_0;  alias, 1 drivers
+v0x55ef6e7d09a0_0 .net "input1", 31 0, L_0x55ef6e7d81f0;  alias, 1 drivers
+v0x55ef6e7d0a80_0 .net "input2", 31 0, L_0x55ef6e7d8ed0;  1 drivers
+v0x55ef6e7d0b40_0 .var "result", 31 0;
+v0x55ef6e7d0c20_0 .var "zero", 0 0;
+E_0x55ef6e75c450 .event anyedge, v0x55ef6e7a01b0_0, v0x55ef6e7d09a0_0, v0x55ef6e7d0a80_0, v0x55ef6e7d0b40_0;
+S_0x55ef6e7d0dd0 .scope module, "alu_ctrl" "ALUControl" 3 68, 4 51 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 2 "ALUOp";
+    .port_info 1 /INPUT 6 "funct";
+    .port_info 2 /OUTPUT 4 "alu_control";
+v0x55ef6e7d1060_0 .net "ALUOp", 1 0, v0x55ef6e7d1640_0;  alias, 1 drivers
+v0x55ef6e7d1160_0 .var "alu_control", 3 0;
+v0x55ef6e7d1220_0 .net "funct", 5 0, L_0x55ef6e7d8e30;  1 drivers
+E_0x55ef6e7b5290 .event anyedge, v0x55ef6e7d1060_0, v0x55ef6e7d1220_0;
+S_0x55ef6e7d1340 .scope module, "control" "ControlUnit" 3 36, 5 2 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 6 "opcode";
+    .port_info 1 /OUTPUT 1 "RegDst";
+    .port_info 2 /OUTPUT 1 "ALUSrc";
+    .port_info 3 /OUTPUT 1 "MemtoReg";
+    .port_info 4 /OUTPUT 1 "RegWrite";
+    .port_info 5 /OUTPUT 1 "MemRead";
+    .port_info 6 /OUTPUT 1 "MemWrite";
+    .port_info 7 /OUTPUT 1 "Branch";
+    .port_info 8 /OUTPUT 1 "Jump";
+    .port_info 9 /OUTPUT 2 "ALUOp";
+v0x55ef6e7d1640_0 .var "ALUOp", 1 0;
+v0x55ef6e7d1700_0 .var "ALUSrc", 0 0;
+v0x55ef6e7d17a0_0 .var "Branch", 0 0;
+v0x55ef6e7d1840_0 .var "Jump", 0 0;
+v0x55ef6e7d1900_0 .var "MemRead", 0 0;
+v0x55ef6e7d1a10_0 .var "MemWrite", 0 0;
+v0x55ef6e7d1ad0_0 .var "MemtoReg", 0 0;
+v0x55ef6e7d1b90_0 .var "RegDst", 0 0;
+v0x55ef6e7d1c50_0 .var "RegWrite", 0 0;
+v0x55ef6e7d1d10_0 .net "opcode", 5 0, L_0x55ef6e7d7f10;  1 drivers
+E_0x55ef6e7b52d0 .event anyedge, v0x55ef6e7d1d10_0;
+S_0x55ef6e7d1f90 .scope module, "data_mem" "DataMemory" 3 84, 6 2 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "MemRead";
+    .port_info 2 /INPUT 1 "MemWrite";
+    .port_info 3 /INPUT 32 "address";
+    .port_info 4 /INPUT 32 "writeData";
+    .port_info 5 /OUTPUT 32 "readData";
+v0x55ef6e7d2200_0 .net "MemRead", 0 0, v0x55ef6e7d1900_0;  alias, 1 drivers
+v0x55ef6e7d22c0_0 .net "MemWrite", 0 0, v0x55ef6e7d1a10_0;  alias, 1 drivers
+v0x55ef6e7d2360_0 .net *"_ivl_0", 31 0, L_0x55ef6e7d8fb0;  1 drivers
+v0x55ef6e7d2400_0 .net *"_ivl_3", 7 0, L_0x55ef6e7d9050;  1 drivers
+v0x55ef6e7d24c0_0 .net *"_ivl_4", 9 0, L_0x55ef6e7d90f0;  1 drivers
+L_0x7ff41cabc0f0 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d25f0_0 .net *"_ivl_7", 1 0, L_0x7ff41cabc0f0;  1 drivers
+L_0x7ff41cabc138 .functor BUFT 1, C4<00000000000000000000000000000000>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d26d0_0 .net/2u *"_ivl_8", 31 0, L_0x7ff41cabc138;  1 drivers
+v0x55ef6e7d27b0_0 .net "address", 31 0, v0x55ef6e7d0b40_0;  alias, 1 drivers
+v0x55ef6e7d2870_0 .net "clk", 0 0, v0x55ef6e7d7870_0;  alias, 1 drivers
+v0x55ef6e7d29a0 .array "memory", 255 0, 31 0;
+v0x55ef6e7d2a60_0 .net "readData", 31 0, L_0x55ef6e7e9290;  alias, 1 drivers
+v0x55ef6e7d2b40_0 .net "writeData", 31 0, L_0x55ef6e7d84c0;  alias, 1 drivers
+E_0x55ef6e7b5940 .event posedge, v0x55ef6e7d2870_0;
+L_0x55ef6e7d8fb0 .array/port v0x55ef6e7d29a0, L_0x55ef6e7d90f0;
+L_0x55ef6e7d9050 .part v0x55ef6e7d0b40_0, 0, 8;
+L_0x55ef6e7d90f0 .concat [ 8 2 0 0], L_0x55ef6e7d9050, L_0x7ff41cabc0f0;
+L_0x55ef6e7e9290 .functor MUXZ 32, L_0x7ff41cabc138, L_0x55ef6e7d8fb0, v0x55ef6e7d1900_0, C4<>;
+S_0x55ef6e7d2ce0 .scope module, "inst_mem" "InstructionMemory" 3 30, 6 37 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 32 "address";
+    .port_info 1 /OUTPUT 32 "instruction";
+L_0x55ef6e7b2bc0 .functor BUFZ 32, L_0x55ef6e7d7b90, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
+v0x55ef6e7d2ee0_0 .net *"_ivl_0", 31 0, L_0x55ef6e7d7b90;  1 drivers
+v0x55ef6e7d2fe0_0 .net *"_ivl_3", 7 0, L_0x55ef6e7d7c50;  1 drivers
+v0x55ef6e7d30c0_0 .net *"_ivl_4", 9 0, L_0x55ef6e7d7d80;  1 drivers
+L_0x7ff41cabc018 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d3180_0 .net *"_ivl_7", 1 0, L_0x7ff41cabc018;  1 drivers
+v0x55ef6e7d3260_0 .net "address", 31 0, v0x55ef6e7d3980_0;  alias, 1 drivers
+v0x55ef6e7d3390_0 .net "instruction", 31 0, L_0x55ef6e7b2bc0;  alias, 1 drivers
+v0x55ef6e7d3470 .array "memory", 255 0, 31 0;
+L_0x55ef6e7d7b90 .array/port v0x55ef6e7d3470, L_0x55ef6e7d7d80;
+L_0x55ef6e7d7c50 .part v0x55ef6e7d3980_0, 0, 8;
+L_0x55ef6e7d7d80 .concat [ 8 2 0 0], L_0x55ef6e7d7c50, L_0x7ff41cabc018;
+S_0x55ef6e7d3590 .scope module, "pc_reg" "PC" 3 22, 6 22 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "rst";
+    .port_info 2 /INPUT 32 "next_pc";
+    .port_info 3 /OUTPUT 32 "pc";
+v0x55ef6e7d37d0_0 .net "clk", 0 0, v0x55ef6e7d7870_0;  alias, 1 drivers
+v0x55ef6e7d38c0_0 .net "next_pc", 31 0, L_0x55ef6e7ea420;  alias, 1 drivers
+v0x55ef6e7d3980_0 .var "pc", 31 0;
+v0x55ef6e7d3a80_0 .net "rst", 0 0, v0x55ef6e7d7aa0_0;  alias, 1 drivers
+E_0x55ef6e7d3770 .event posedge, v0x55ef6e7d3a80_0, v0x55ef6e7d2870_0;
+S_0x55ef6e7d3bd0 .scope module, "reg_file" "Registers" 3 50, 4 22 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "RegWrite";
+    .port_info 2 /INPUT 5 "readReg1";
+    .port_info 3 /INPUT 5 "readReg2";
+    .port_info 4 /INPUT 5 "writeReg";
+    .port_info 5 /INPUT 32 "writeData";
+    .port_info 6 /OUTPUT 32 "readData1";
+    .port_info 7 /OUTPUT 32 "readData2";
+L_0x55ef6e7d81f0 .functor BUFZ 32, L_0x55ef6e7d8040, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
+L_0x55ef6e7d84c0 .functor BUFZ 32, L_0x55ef6e7d82b0, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>, C4<00000000000000000000000000000000>;
+v0x55ef6e7d3ed0_0 .net "RegWrite", 0 0, v0x55ef6e7d1c50_0;  alias, 1 drivers
+v0x55ef6e7d3f90_0 .net *"_ivl_0", 31 0, L_0x55ef6e7d8040;  1 drivers
+v0x55ef6e7d4050_0 .net *"_ivl_10", 6 0, L_0x55ef6e7d8350;  1 drivers
+L_0x7ff41cabc0a8 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d4140_0 .net *"_ivl_13", 1 0, L_0x7ff41cabc0a8;  1 drivers
+v0x55ef6e7d4220_0 .net *"_ivl_2", 6 0, L_0x55ef6e7d8100;  1 drivers
+L_0x7ff41cabc060 .functor BUFT 1, C4<00>, C4<0>, C4<0>, C4<0>;
+v0x55ef6e7d4350_0 .net *"_ivl_5", 1 0, L_0x7ff41cabc060;  1 drivers
+v0x55ef6e7d4430_0 .net *"_ivl_8", 31 0, L_0x55ef6e7d82b0;  1 drivers
+v0x55ef6e7d4510_0 .net "clk", 0 0, v0x55ef6e7d7870_0;  alias, 1 drivers
+v0x55ef6e7d4600_0 .var/i "i", 31 0;
+v0x55ef6e7d4770_0 .net "readData1", 31 0, L_0x55ef6e7d81f0;  alias, 1 drivers
+v0x55ef6e7d4830_0 .net "readData2", 31 0, L_0x55ef6e7d84c0;  alias, 1 drivers
+v0x55ef6e7d48d0_0 .net "readReg1", 4 0, L_0x55ef6e7d8580;  1 drivers
+v0x55ef6e7d4990_0 .net "readReg2", 4 0, L_0x55ef6e7d8670;  1 drivers
+v0x55ef6e7d4a70 .array "regFile", 0 31, 31 0;
+v0x55ef6e7d4b30_0 .net "writeData", 31 0, L_0x55ef6e7e9290;  alias, 1 drivers
+v0x55ef6e7d4c20_0 .net "writeReg", 4 0, L_0x55ef6e7e9590;  alias, 1 drivers
+L_0x55ef6e7d8040 .array/port v0x55ef6e7d4a70, L_0x55ef6e7d8100;
+L_0x55ef6e7d8100 .concat [ 5 2 0 0], L_0x55ef6e7d8580, L_0x7ff41cabc060;
+L_0x55ef6e7d82b0 .array/port v0x55ef6e7d4a70, L_0x55ef6e7d8350;
+L_0x55ef6e7d8350 .concat [ 5 2 0 0], L_0x55ef6e7d8670, L_0x7ff41cabc0a8;
+S_0x55ef6e7d4de0 .scope module, "sign_ext" "SignExtend" 3 62, 6 53 0, S_0x55ef6e7a7250;
+ .timescale 0 0;
+    .port_info 0 /INPUT 16 "in";
+    .port_info 1 /OUTPUT 32 "out";
+v0x55ef6e7d4fd0_0 .net *"_ivl_1", 0 0, L_0x55ef6e7d8760;  1 drivers
+v0x55ef6e7d50d0_0 .net *"_ivl_2", 15 0, L_0x55ef6e7d8800;  1 drivers
+v0x55ef6e7d51b0_0 .net "in", 15 0, L_0x55ef6e7d8d60;  1 drivers
+v0x55ef6e7d52a0_0 .net "out", 31 0, L_0x55ef6e7d8c20;  alias, 1 drivers
+L_0x55ef6e7d8760 .part L_0x55ef6e7d8d60, 15, 1;
+LS_0x55ef6e7d8800_0_0 .concat [ 1 1 1 1], L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760;
+LS_0x55ef6e7d8800_0_4 .concat [ 1 1 1 1], L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760;
+LS_0x55ef6e7d8800_0_8 .concat [ 1 1 1 1], L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760;
+LS_0x55ef6e7d8800_0_12 .concat [ 1 1 1 1], L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760, L_0x55ef6e7d8760;
+L_0x55ef6e7d8800 .concat [ 4 4 4 4], LS_0x55ef6e7d8800_0_0, LS_0x55ef6e7d8800_0_4, LS_0x55ef6e7d8800_0_8, LS_0x55ef6e7d8800_0_12;
+L_0x55ef6e7d8c20 .concat [ 16 16 0 0], L_0x55ef6e7d8d60, L_0x55ef6e7d8800;
+    .scope S_0x55ef6e7d3590;
+T_0 ;
+    %wait E_0x55ef6e7d3770;
+    %load/vec4 v0x55ef6e7d3a80_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.0, 8;
+    %pushi/vec4 0, 0, 32;
+    %assign/vec4 v0x55ef6e7d3980_0, 0;
+    %jmp T_0.1;
+T_0.0 ;
+    %load/vec4 v0x55ef6e7d38c0_0;
+    %assign/vec4 v0x55ef6e7d3980_0, 0;
+T_0.1 ;
+    %jmp T_0;
+    .thread T_0;
+    .scope S_0x55ef6e7d2ce0;
+T_1 ;
+    %vpi_call 6 45 "$readmemh", "Test.mem", v0x55ef6e7d3470 {0 0 0};
+    %end;
+    .thread T_1;
+    .scope S_0x55ef6e7d1340;
+T_2 ;
+    %wait E_0x55ef6e7b52d0;
+    %load/vec4 v0x55ef6e7d1d10_0;
+    %dup/vec4;
+    %pushi/vec4 0, 0, 6;
+    %cmp/u;
+    %jmp/1 T_2.0, 6;
+    %dup/vec4;
+    %pushi/vec4 35, 0, 6;
+    %cmp/u;
+    %jmp/1 T_2.1, 6;
+    %dup/vec4;
+    %pushi/vec4 43, 0, 6;
+    %cmp/u;
+    %jmp/1 T_2.2, 6;
+    %dup/vec4;
+    %pushi/vec4 4, 0, 6;
+    %cmp/u;
+    %jmp/1 T_2.3, 6;
+    %dup/vec4;
+    %pushi/vec4 2, 0, 6;
+    %cmp/u;
+    %jmp/1 T_2.4, 6;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.0 ;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 2, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.1 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.2 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.3 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 1, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.4 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1b90_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1700_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1ad0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1c50_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1900_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d1a10_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d17a0_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d1840_0, 0, 1;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x55ef6e7d1640_0, 0, 2;
+    %jmp T_2.6;
+T_2.6 ;
+    %pop/vec4 1;
+    %jmp T_2;
+    .thread T_2, $push;
+    .scope S_0x55ef6e7d3bd0;
+T_3 ;
+    %pushi/vec4 0, 0, 32;
+    %store/vec4 v0x55ef6e7d4600_0, 0, 32;
+T_3.0 ;
+    %load/vec4 v0x55ef6e7d4600_0;
+    %cmpi/s 32, 0, 32;
+    %jmp/0xz T_3.1, 5;
+    %pushi/vec4 0, 0, 32;
+    %ix/getv/s 4, v0x55ef6e7d4600_0;
+    %store/vec4a v0x55ef6e7d4a70, 4, 0;
+    %load/vec4 v0x55ef6e7d4600_0;
+    %addi 1, 0, 32;
+    %store/vec4 v0x55ef6e7d4600_0, 0, 32;
+    %jmp T_3.0;
+T_3.1 ;
+    %end;
+    .thread T_3;
+    .scope S_0x55ef6e7d3bd0;
+T_4 ;
+    %wait E_0x55ef6e7b5940;
+    %load/vec4 v0x55ef6e7d3ed0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_4.0, 8;
+    %load/vec4 v0x55ef6e7d4b30_0;
+    %load/vec4 v0x55ef6e7d4c20_0;
+    %pad/u 7;
+    %ix/vec4 3;
+    %ix/load 4, 0, 0; Constant delay
+    %assign/vec4/a/d v0x55ef6e7d4a70, 0, 4;
+T_4.0 ;
+    %jmp T_4;
+    .thread T_4;
+    .scope S_0x55ef6e7d0dd0;
+T_5 ;
+    %wait E_0x55ef6e7b5290;
+    %load/vec4 v0x55ef6e7d1060_0;
+    %dup/vec4;
+    %pushi/vec4 0, 0, 2;
+    %cmp/u;
+    %jmp/1 T_5.0, 6;
+    %dup/vec4;
+    %pushi/vec4 1, 0, 2;
+    %cmp/u;
+    %jmp/1 T_5.1, 6;
+    %dup/vec4;
+    %pushi/vec4 2, 0, 2;
+    %cmp/u;
+    %jmp/1 T_5.2, 6;
+    %pushi/vec4 0, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.4;
+T_5.0 ;
+    %pushi/vec4 2, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.4;
+T_5.1 ;
+    %pushi/vec4 6, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.4;
+T_5.2 ;
+    %load/vec4 v0x55ef6e7d1220_0;
+    %dup/vec4;
+    %pushi/vec4 32, 0, 6;
+    %cmp/u;
+    %jmp/1 T_5.5, 6;
+    %dup/vec4;
+    %pushi/vec4 34, 0, 6;
+    %cmp/u;
+    %jmp/1 T_5.6, 6;
+    %dup/vec4;
+    %pushi/vec4 36, 0, 6;
+    %cmp/u;
+    %jmp/1 T_5.7, 6;
+    %dup/vec4;
+    %pushi/vec4 37, 0, 6;
+    %cmp/u;
+    %jmp/1 T_5.8, 6;
+    %dup/vec4;
+    %pushi/vec4 42, 0, 6;
+    %cmp/u;
+    %jmp/1 T_5.9, 6;
+    %pushi/vec4 0, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.5 ;
+    %pushi/vec4 2, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.6 ;
+    %pushi/vec4 6, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.7 ;
+    %pushi/vec4 0, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.8 ;
+    %pushi/vec4 1, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.9 ;
+    %pushi/vec4 7, 0, 4;
+    %store/vec4 v0x55ef6e7d1160_0, 0, 4;
+    %jmp T_5.11;
+T_5.11 ;
+    %pop/vec4 1;
+    %jmp T_5.4;
+T_5.4 ;
+    %pop/vec4 1;
+    %jmp T_5;
+    .thread T_5, $push;
+    .scope S_0x55ef6e7b5d70;
+T_6 ;
+    %wait E_0x55ef6e75c450;
+    %load/vec4 v0x55ef6e7a01b0_0;
+    %dup/vec4;
+    %pushi/vec4 2, 0, 4;
+    %cmp/u;
+    %jmp/1 T_6.0, 6;
+    %dup/vec4;
+    %pushi/vec4 6, 0, 4;
+    %cmp/u;
+    %jmp/1 T_6.1, 6;
+    %dup/vec4;
+    %pushi/vec4 0, 0, 4;
+    %cmp/u;
+    %jmp/1 T_6.2, 6;
+    %dup/vec4;
+    %pushi/vec4 1, 0, 4;
+    %cmp/u;
+    %jmp/1 T_6.3, 6;
+    %dup/vec4;
+    %pushi/vec4 7, 0, 4;
+    %cmp/u;
+    %jmp/1 T_6.4, 6;
+    %pushi/vec4 0, 0, 32;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.0 ;
+    %load/vec4 v0x55ef6e7d09a0_0;
+    %load/vec4 v0x55ef6e7d0a80_0;
+    %add;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.1 ;
+    %load/vec4 v0x55ef6e7d09a0_0;
+    %load/vec4 v0x55ef6e7d0a80_0;
+    %sub;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.2 ;
+    %load/vec4 v0x55ef6e7d09a0_0;
+    %load/vec4 v0x55ef6e7d0a80_0;
+    %and;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.3 ;
+    %load/vec4 v0x55ef6e7d09a0_0;
+    %load/vec4 v0x55ef6e7d0a80_0;
+    %or;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.4 ;
+    %load/vec4 v0x55ef6e7d09a0_0;
+    %load/vec4 v0x55ef6e7d0a80_0;
+    %cmp/u;
+    %flag_mov 8, 5;
+    %jmp/0 T_6.7, 8;
+    %pushi/vec4 1, 0, 32;
+    %jmp/1 T_6.8, 8;
+T_6.7 ; End of true expr.
+    %pushi/vec4 0, 0, 32;
+    %jmp/0 T_6.8, 8;
+ ; End of false expr.
+    %blend;
+T_6.8;
+    %store/vec4 v0x55ef6e7d0b40_0, 0, 32;
+    %jmp T_6.6;
+T_6.6 ;
+    %pop/vec4 1;
+    %load/vec4 v0x55ef6e7d0b40_0;
+    %cmpi/e 0, 0, 32;
+    %flag_mov 8, 4;
+    %jmp/0 T_6.9, 8;
+    %pushi/vec4 1, 0, 2;
+    %jmp/1 T_6.10, 8;
+T_6.9 ; End of true expr.
+    %pushi/vec4 0, 0, 2;
+    %jmp/0 T_6.10, 8;
+ ; End of false expr.
+    %blend;
+T_6.10;
+    %pad/s 1;
+    %store/vec4 v0x55ef6e7d0c20_0, 0, 1;
+    %jmp T_6;
+    .thread T_6, $push;
+    .scope S_0x55ef6e7d1f90;
+T_7 ;
+    %wait E_0x55ef6e7b5940;
+    %load/vec4 v0x55ef6e7d22c0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_7.0, 8;
+    %load/vec4 v0x55ef6e7d2b40_0;
+    %load/vec4 v0x55ef6e7d27b0_0;
+    %parti/s 8, 0, 2;
+    %pad/u 10;
+    %ix/vec4 3;
+    %ix/load 4, 0, 0; Constant delay
+    %assign/vec4/a/d v0x55ef6e7d29a0, 0, 4;
+T_7.0 ;
+    %jmp T_7;
+    .thread T_7;
+    .scope S_0x55ef6e7aaf20;
+T_8 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d7870_0, 0, 1;
+T_8.0 ;
+    %delay 5000, 0;
+    %load/vec4 v0x55ef6e7d7870_0;
+    %inv;
+    %store/vec4 v0x55ef6e7d7870_0, 0, 1;
+    %jmp T_8.0;
+    %end;
+    .thread T_8;
+    .scope S_0x55ef6e7aaf20;
+T_9 ;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x55ef6e7d7aa0_0, 0, 1;
+    %delay 10000, 0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x55ef6e7d7aa0_0, 0, 1;
+    %delay 200000, 0;
+    %ix/load 4, 8, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %cmpi/e 5, 0, 32;
+    %flag_get/vec4 4;
+    %jmp/0 T_9.9, 4;
+    %ix/load 4, 9, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 10, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.9;
+    %flag_set/vec4 15;
+    %flag_get/vec4 15;
+    %jmp/0 T_9.8, 15;
+    %ix/load 4, 10, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 15, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.8;
+    %flag_set/vec4 14;
+    %flag_get/vec4 14;
+    %jmp/0 T_9.7, 14;
+    %ix/load 4, 11, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 5, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.7;
+    %flag_set/vec4 13;
+    %flag_get/vec4 13;
+    %jmp/0 T_9.6, 13;
+    %ix/load 4, 15, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 2, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.6;
+    %flag_set/vec4 12;
+    %flag_get/vec4 12;
+    %jmp/0 T_9.5, 12;
+    %ix/load 4, 24, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 999, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.5;
+    %flag_set/vec4 11;
+    %flag_get/vec4 11;
+    %jmp/0 T_9.4, 11;
+    %ix/load 4, 25, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 0, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.4;
+    %flag_set/vec4 10;
+    %flag_get/vec4 10;
+    %jmp/0 T_9.3, 10;
+    %ix/load 4, 16, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 15, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.3;
+    %flag_set/vec4 9;
+    %flag_get/vec4 9;
+    %jmp/0 T_9.2, 9;
+    %ix/load 4, 17, 0;
+    %flag_set/imm 4, 0;
+    %load/vec4a v0x55ef6e7d4a70, 4;
+    %pushi/vec4 1, 0, 32;
+    %cmp/e;
+    %flag_get/vec4 4;
+    %and;
+T_9.2;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_9.0, 8;
+    %vpi_call 2 52 "$display", "Teste passou!" {0 0 0};
+    %jmp T_9.1;
+T_9.0 ;
+    %vpi_call 2 54 "$display", "Teste falhou!" {0 0 0};
+    %vpi_call 2 55 "$display", "Valores dos registradores:" {0 0 0};
+    %vpi_call 2 56 "$display", "$t0 (reg[8]): %h", &A<v0x55ef6e7d4a70, 8> {0 0 0};
+    %vpi_call 2 57 "$display", "$t1 (reg[9]): %h", &A<v0x55ef6e7d4a70, 9> {0 0 0};
+    %vpi_call 2 58 "$display", "$t2 (reg[10]): %h", &A<v0x55ef6e7d4a70, 10> {0 0 0};
+    %vpi_call 2 59 "$display", "$t3 (reg[11]): %h", &A<v0x55ef6e7d4a70, 11> {0 0 0};
+    %vpi_call 2 60 "$display", "$t7 (reg[15]): %h", &A<v0x55ef6e7d4a70, 15> {0 0 0};
+    %vpi_call 2 61 "$display", "$t8 (reg[24]): %h", &A<v0x55ef6e7d4a70, 24> {0 0 0};
+    %vpi_call 2 62 "$display", "$t9 (reg[25]): %h", &A<v0x55ef6e7d4a70, 25> {0 0 0};
+    %vpi_call 2 63 "$display", "$s0 (reg[16]): %h", &A<v0x55ef6e7d4a70, 16> {0 0 0};
+    %vpi_call 2 64 "$display", "$s1 (reg[17]): %h", &A<v0x55ef6e7d4a70, 17> {0 0 0};
+T_9.1 ;
+    %vpi_call 2 68 "$finish" {0 0 0};
+    %end;
+    .thread T_9;
+    .scope S_0x55ef6e7aaf20;
+T_10 ;
+    %vpi_call 2 72 "$monitor", "Tempo: %0d | PC: %h | Instru\303\247\303\243o: %h | RegWrite: %b | ALUSrc: %b | Branch: %b | Jump: %b", $time, v0x55ef6e7d7a00_0, v0x55ef6e7d7960_0, v0x55ef6e7d77d0_0, v0x55ef6e7d7510_0, v0x55ef6e7d75d0_0, v0x55ef6e7d76e0_0 {0 0 0};
+    %end;
+    .thread T_10;
+    .scope S_0x55ef6e7aaf20;
+T_11 ;
+    %vpi_call 2 83 "$monitor", "Tempo: %0d | $t0: %h | $t1: %h | $t2: %h | $t3: %h | $t7: %h | $t8: %h | $t9: %h | $s0: %h | $s1: %h", $time, &A<v0x55ef6e7d4a70, 8>, &A<v0x55ef6e7d4a70, 9>, &A<v0x55ef6e7d4a70, 10>, &A<v0x55ef6e7d4a70, 11>, &A<v0x55ef6e7d4a70, 15>, &A<v0x55ef6e7d4a70, 24>, &A<v0x55ef6e7d4a70, 25>, &A<v0x55ef6e7d4a70, 16>, &A<v0x55ef6e7d4a70, 17> {0 0 0};
+    %end;
+    .thread T_11;
+    .scope S_0x55ef6e7aaf20;
+T_12 ;
+    %vpi_call 2 98 "$dumpfile", "Processador.vcd" {0 0 0};
+    %vpi_call 2 99 "$dumpvars", 32'sb00000000000000000000000000000000, S_0x55ef6e7a7250 {0 0 0};
+    %end;
+    .thread T_12;
+    .scope S_0x55ef6e7aaf20;
+T_13 ;
+    %vpi_call 2 103 "$monitor", "Tempo: %0d | Mem[0x10010010]: %h", $time, &A<v0x55ef6e7d29a0, 16> {0 0 0};
+    %end;
+    .thread T_13;
+    .scope S_0x55ef6e7aaf20;
+T_14 ;
+    %vpi_call 2 110 "$readmemh", "Teste.mem", v0x55ef6e7d3470 {0 0 0};
+    %vpi_call 2 111 "$display", "Arquivo Teste.mem carregado com sucesso!" {0 0 0};
+    %end;
+    .thread T_14;
+# The file index is used to find the file name in the following table.
+:file_names 7;
+    "N/A";
+    "<interactive>";
+    "simulacao.v";
+    "Processador.v";
+    "AluAndRegistradores.v";
+    "UnidadeDeControle.v";
+    "memory.v";

--- a/Processador Ciclo Unico/simulacao.v
+++ b/Processador Ciclo Unico/simulacao.v
@@ -9,11 +9,18 @@ module SingleCycleMIPS_Simulation;
     // Fios de saída do processador
     wire [31:0] pc;
     wire [31:0] instruction;
+    wire RegWrite, ALUSrc, Branch, Jump;
 
     // Instância do processador
     SingleCycleMIPS uut (
         .clk(clk),
-        .rst(rst)
+        .rst(rst),
+        .pc(pc),
+        .instruction(instruction),
+        .RegWrite(RegWrite),
+        .ALUSrc(ALUSrc),
+        .Branch(Branch),
+        .Jump(Jump)
     );
 
     // Gerador de clock
@@ -60,39 +67,44 @@ module SingleCycleMIPS_Simulation;
         // Finaliza a simulação
         $finish;
     end
-initial begin
-    $monitor("Tempo: %0d | PC: %h | Instrução: %h | RegWrite: %b | ALUSrc: %b | Branch: %b | Jump: %b", 
-             $time, 
-             pc, 
-             instruction,
-             RegWrite,
-             ALUSrc,
-             Branch,
-             Jump);
-end
-initial begin
-    $monitor("Tempo: %0d | $t0: %h | $t1: %h | $t2: %h | $t3: %h | $t7: %h | $t8: %h | $t9: %h | $s0: %h | $s1: %h", 
-             $time, 
-             reg_file.regFile[8],  // $t0
-             reg_file.regFile[9],  // $t1
-             reg_file.regFile[10], // $t2
-             reg_file.regFile[11], // $t3
-             reg_file.regFile[15], // $t7
-             reg_file.regFile[24], // $t8
-             reg_file.regFile[25], // $t9
-             reg_file.regFile[16], // $s0
-             reg_file.regFile[17]  // $s1
-            );
-end
-initial begin
-    $dumpfile("Processador.vcd");
-    $dumpvars(0, Processador);
-end
-initial begin
-    $monitor("Tempo: %0d | Mem[0x10010010]: %h", 
-             $time, 
-             data_mem.memory[16]); // Endereço 0x10010010
-end
+
+    initial begin
+        $monitor("Tempo: %0d | PC: %h | Instrução: %h | RegWrite: %b | ALUSrc: %b | Branch: %b | Jump: %b", 
+                 $time, 
+                 pc, 
+                 instruction,
+                 RegWrite,
+                 ALUSrc,
+                 Branch,
+                 Jump);
+    end
+
+    initial begin
+        $monitor("Tempo: %0d | $t0: %h | $t1: %h | $t2: %h | $t3: %h | $t7: %h | $t8: %h | $t9: %h | $s0: %h | $s1: %h", 
+                 $time, 
+                 uut.reg_file.regFile[8],  // $t0
+                 uut.reg_file.regFile[9],  // $t1
+                 uut.reg_file.regFile[10], // $t2
+                 uut.reg_file.regFile[11], // $t3
+                 uut.reg_file.regFile[15], // $t7
+                 uut.reg_file.regFile[24], // $t8
+                 uut.reg_file.regFile[25], // $t9
+                 uut.reg_file.regFile[16], // $s0
+                 uut.reg_file.regFile[17]  // $s1
+                );
+    end
+
+    initial begin
+        $dumpfile("Processador.vcd");
+        $dumpvars(0, uut);
+    end
+
+    initial begin
+        $monitor("Tempo: %0d | Mem[0x10010010]: %h", 
+                 $time, 
+                 uut.data_mem.memory[16]); // Endereço 0x10010010
+    end
+
     // Carregar instruções no arquivo de memória
     initial begin
         $readmemh("Teste.mem", uut.inst_mem.memory);


### PR DESCRIPTION
# Descrição das Modificações

## Arquivo: simulacao.v

### Modificações:
1. Adição de fios (`wire`) para `RegWrite`, `ALUSrc`, `Branch` e `Jump`.
2. Conexão dos fios aos sinais correspondentes na instância do processador (`uut`).
3. Correção das referências aos registradores e memória dentro da instância do processador (`uut`).

### Razões:
- As modificações foram necessárias para corrigir os erros de ligação de sinais e referências internas na simulação. Os sinais `RegWrite`, `ALUSrc`, `Branch` e `Jump` precisavam ser conectados corretamente à instância do processador para monitoramento durante a simulação.

## Arquivo: Processador.v

### Modificações:
1. Adição de portas de saída (`output`) para `pc`, `instruction`, `RegWrite`, `ALUSrc`, `Branch` e `Jump`.

### Razões:
- As portas de saída foram adicionadas para expor os sinais internos do processador, permitindo que eles sejam monitorados na simulação (`simulacao.v`). Isso é essencial para verificar o comportamento do processador durante a execução das instruções.

## Arquivo: UnidadeDeControle.v

### Modificações:
Nenhuma modificação necessária.

### Razões:
- O arquivo `UnidadeDeControle.v` já estava correto e não necessitou de alterações.

## Arquivo: memory.v

### Modificações:
Nenhuma modificação necessária.

### Razões:
- O arquivo `memory.v` já estava correto e não necessitou de alterações.

## Arquivo: AluAndRegistradores.v

### Modificações:
Nenhuma modificação necessária.

### Razões:
- O arquivo `AluAndRegistradores.v` já estava correto e não necessitou de alterações.

# Conclusão

As modificações realizadas foram essenciais para corrigir os erros de ligação de sinais e referências internas na simulação do processador de ciclo único. Com essas mudanças, a simulação agora pode monitorar corretamente os sinais internos do processador, permitindo uma verificação mais precisa do seu comportamento.
